### PR TITLE
COMPASS-3720: edit document tab events to for tracking

### DIFF
--- a/src/modules/rules.js
+++ b/src/modules/rules.js
@@ -85,7 +85,7 @@ const RULES = [
     action: 'updated',
     condition: () => true,
     metadata: (view, screen) => ({
-      'screen': screen || 'List',
+      'screen': screen,
       'view': view
     })
   },
@@ -95,8 +95,8 @@ const RULES = [
     action: 'inserted',
     condition: () => true,
     metadata: (view, mode, multiple) => ({
-      'mode': mode || 'JSON',
-      'multiple': multiple || false,
+      'mode': mode,
+      'multiple': multiple,
       'view': view
     })
   },


### PR DESCRIPTION
## Description

Editing `document-inserted` and `document-updated` events to include current insert document mode. 

Adding `document-view-changed` to track when a user toggled between `List`/`Json`/`Table` views.

## Semver
- [x] Minor