### PR TITLE
COMPASS-4351: Add compass shell telemetry events and remove community references

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -30,7 +30,7 @@ const config = {
         use: [{
           loader: 'file-loader',
           // In prod we need to go to $COMPASS_HOME/node_modules/<plugin>/lib or
-          // $USER_HOME/.mongodb/compasss(-community)/plugins
+          // $USER_HOME/.mongodb/compass/plugins
           //
           // @note This currently does not work in published plugin.
           query: {
@@ -46,7 +46,7 @@ const config = {
         use: [{
           loader: 'file-loader',
           // In prod we need to go to $COMPASS_HOME/node_modules/<plugin>/lib or
-          // $USER_HOME/.mongodb/compasss(-community)/plugins
+          // $USER_HOME/.mongodb/compass/plugins
           //
           // @note This currently does not work in published plugin.
           query: {

--- a/src/modules/features.js
+++ b/src/modules/features.js
@@ -288,6 +288,9 @@ const ShellResource = BaseResource.extend({
   },
   ['api-call']: function(metadata, callback) {
     this._send_event(metadata, callback);
+  },
+  error: function(metadata, callback) {
+    this._send_event(metadata, callback);
   }
 });
 

--- a/src/modules/features.js
+++ b/src/modules/features.js
@@ -274,6 +274,23 @@ const TourResource = BaseResource.extend({
   }
 });
 
+const ShellResource = BaseResource.extend({
+  id: 'Shell',
+  eventTrackers: ['stitch'],
+  opened: function(metadata, callback) {
+    this._send_event(metadata, callback);
+  },
+  show: function(metadata, callback) {
+    this._send_event(metadata, callback);
+  },
+  use: function(metadata, callback) {
+    this._send_event(metadata, callback);
+  },
+  ['api-call']: function(metadata, callback) {
+    this._send_event(metadata, callback);
+  }
+});
+
 // Screen resource.
 const ScreenResource = BaseResource.extend({
   id: 'Screen',
@@ -290,6 +307,7 @@ featureResources['Auto Update'] = new AutoUpdateResource();
 featureResources.Collection = new CollectionResource();
 featureResources.AtlasLink = new AtlasLinkResource();
 featureResources.Deployment = new DeploymentResource();
+featureResources.Shell = new ShellResource();
 featureResources.Schema = new SchemaResource();
 featureResources.Indexes = new IndexesResource();
 featureResources['Collection Stats'] = new CollectionStatsResource();

--- a/src/modules/rules.js
+++ b/src/modules/rules.js
@@ -15,19 +15,20 @@ async function getCloudInfoFromDataService(dataService) {
 }
 
 /**
- * This file defines rules for tracking metrics based on Reflux store changes.
+ * This file defines rules for tracking metrics based
+ * on store changes and registry events.
  *
  * Each rule is an object with the following keys:
  *
- * @param {String} store        Which store to listen to (e.g. "App.InstanceStore")
- * @param {String} resource     The metrics resource to trigger (e.g. "App",
- *                              "Deployment", ...)
- * @param {String} action       Which action to trigger on the resource (e.g.
- *                              "launched", "detected", ...)
- * @param {Function} condition  Function that receives the store state, and
- *                              returns whether or not the event should be tracked.
- * @param {Function} metadata   Function that receives the store state, and
- *                              returns a metadata object to attach to the event.
+ * @param {String} registryEvent  Which event to listen to (e.g. "compass:screen:viewed")
+ * @param {String} resource       The metrics resource to trigger (e.g. "App",
+ *                                "Deployment", ...)
+ * @param {String} action         Which action to trigger on the resource (e.g.
+ *                                "launched", "detected", ...)
+ * @param {Function} condition    Function that receives the store state, and
+ *                                returns whether or not the event should be tracked.
+ * @param {Function} metadata     Function that receives the store state, and
+ *                                returns a metadata object to attach to the event.
  */
 const RULES = [
   {
@@ -442,6 +443,45 @@ const RULES = [
     condition: () => true,
     metadata: (version) => ({
       compass_version: version
+    })
+  },
+  {
+    registryEvent: 'compass:compass-shell:opened',
+    resource: 'Shell',
+    action: 'opened',
+    condition: () => true,
+    metadata: (version) => ({
+      compass_version: version
+    })
+  },
+  {
+    registryEvent: 'mongosh:show',
+    resource: 'Shell',
+    action: 'show',
+    condition: () => true,
+    metadata: (version, data) => ({
+      compass_version: version,
+      properties: { method: data.method }
+    })
+  },
+  {
+    registryEvent: 'mongosh:use',
+    resource: 'Shell',
+    action: 'use',
+    condition: () => true,
+    metadata: (version) => ({
+      compass_version: version
+    })
+  },
+  {
+    registryEvent: 'mongosh:api-call',
+    resource: 'Shell',
+    action: 'api-call',
+    condition: () => true,
+    metadata: (version, data) => ({
+      compass_version: version,
+      method: data.method,
+      class: data.class
     })
   }
 ];

--- a/src/modules/rules.js
+++ b/src/modules/rules.js
@@ -483,6 +483,21 @@ const RULES = [
       method: data.method,
       class: data.class
     })
+  },
+  {
+    registryEvent: 'mongosh:error',
+    resource: 'Shell',
+    action: 'error',
+    condition: (error) => {
+      // Only report Mongosh errors (not user / mongo errors).
+      return error && error.name && error.name.includes('Mongosh');
+    },
+    metadata: (version, error) => ({
+      compass_version: version,
+      properties: {
+        error
+      }
+    })
   }
 ];
 

--- a/src/modules/setup.js
+++ b/src/modules/setup.js
@@ -15,7 +15,6 @@ const debug = require('debug')('mongodb-compass:metrics:setup');
 const INTERCOM_KEY = process.env.HARDRON_METRICS_INTERCOM_APP_ID;
 const BUGSNAG_KEY = process.env.HARDRON_METRICS_BUGSNAG_KEY;
 const STITCH_APP = process.env.HARDRON_METRICS_STITCH_APP_ID;
-const COMMUNITY = 'mongodb-compass-community';
 
 /**
  * Setup all the metrics resources to track.
@@ -53,7 +52,7 @@ const setupMetrics = (appRegistry, productName, version) => {
     // When using an App that can have Intercom support, we need to double check against
     // customers who have firewalls that block out intercom as it tries to make requests
     // when set up. Potential todo is to move Intercom into its own plugin as well.
-    if (process.env.HADRON_PRODUCT !== COMMUNITY && app.preferences.enableFeedbackPanel) {
+    if (app.preferences.enableFeedbackPanel) {
       const request = new XMLHttpRequest();
       request.onreadystatechange = () => {
         try {
@@ -176,8 +175,7 @@ const setupMetrics = (appRegistry, productName, version) => {
      * such that when a link is clicked, the event is properly
      * passed off to `app.router` and a web page actually opens.
      */
-    if (process.env.HADRON_PRODUCT !== COMMUNITY &&
-        !intercomBlocked &&
+    if (!intercomBlocked &&
         app.preferences.enableFeedbackPanel) {
       configureIntercom();
     }


### PR DESCRIPTION
COMPASS-4351

This PR adds rules for handling the following events from the `compass-shell` plugin:
- `compass:compass-shell:opened`
- `mongosh:show`
- `mongosh:use`
- `mongosh:api-call`
Here's the PR that adds the events: https://github.com/mongodb-js/mongosh/pull/262

Also a bit of removing `community` references.

Thinking about this package a bit - testing is tough because of the tight coupling with [mongodb-js-metrics](https://github.com/mongodb-js/metrics) I think we might be better off having them live in one package since this is the only current dependent on `mongodb-js-metrics`. It could improve testability (currently this package has pretty limited tests). Maybe I'm missing some of the motivation for the two packages being isolated?

After merging this I'll do a patch release and update the version in compass. 